### PR TITLE
Untitled

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/system_management.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/system_management.py
@@ -157,8 +157,7 @@ class pluginclass( object ):
 		
 		if ( self.showTerminal == True ):
 			Button4 = easyButton( self.term, self.iconsize, [_("Terminal")], -1, -1 )
-			Button4.connect( "clicked", self.ButtonClicked, 
-self.term )
+			Button4.connect( "clicked", self.ButtonClicked, self.term )
 			Button4.show()
 			self.systemBtnHolder.pack_start( Button4, False, False )
 			self.mintMenuWin.setTooltip( Button4, _("Use the command line") )


### PR DESCRIPTION
Uses /desktop/gnome/applications/terminal in gconf to work out which terminal to launch (rather than defaulting to gnome-terminal).

Does mean that it misses the /usr/bin/x-terminal-emulator script (although that could be set in gconf to be the terminal used)
