### PR TITLE
Fix Minor issues with favorite menu and others

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -1120,7 +1120,7 @@ class pluginclass( object ):
         #menu.reposition()
         #menu.reposition()
         #self.mintMenuWin.grab()
-        mTree.connect( 'deactivate', self.onMenuPopupDeactivate)
+        menu.connect( 'deactivate', self.onMenuPopupDeactivate)
         self.focusSearchEntry()
         return True
         


### PR DESCRIPTION
This started with my facing https://github.com/linuxmint/mintmenu/issues/45 and its connected forum post, and the lack of any response in either forum. 

I fixed that and a few other minor issues (not sure if right way but they seem so in most cases)

A few are left
- Type something + Click search - text lost  - This is because of modification to focusSearchEntry function
- Type something + click favorite - first click clears the search, second does the toggle - not sure

Much of what I fixed have resulted from 2 commit earlier this year, https://github.com/linuxmint/mintmenu/commit/84aa87727f6341a441fb1e5cb32e3bbe857e44a5 for the first unresolved issue, https://github.com/linuxmint/mintmenu/commit/8812475eac9b267ecead6a92cc1708035c88d086 for all the focus issues, as ironic as that is..
