### PR TITLE
Fixes transparency issues on first composited draw

### DIFF
--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -101,7 +101,6 @@ class MainWindow( object ):
                       
         self.getSetGSettingEntries()
         self.SetupMintMenuBorder()
-        self.SetupMintMenuOpacity()
 
         self.tooltips = Gtk.Tooltips()
         if self.globalEnableTooltips and self.enableTooltips:
@@ -124,6 +123,8 @@ class MainWindow( object ):
         self.settings.connect( "changed::custom-color", self.toggleCustomBackgroundColor )
         self.settings.connect( "changed::border-width", self.toggleBorderWidth )
         self.settings.connect( "changed::opacity", self.toggleOpacity )
+        
+        self.firstTime = True;
 
     def on_window1_destroy (self, widget, data=None):
         Gtk.main_quit()
@@ -436,6 +437,11 @@ class MainWindow( object ):
 
     def show( self ):
         self.window.present()
+        
+        # Hack for opacity not showing on first composited draw
+        if self.firstTime:
+            self.firstTime = False
+            self.SetupMintMenuOpacity()
 
         if ( "applications" in self.plugins ) and ( hasattr( self.plugins["applications"], "focusSearchEntry" ) ):
             if (self.startWithFavorites):


### PR DESCRIPTION
When using compositing and transparency, the first draw was only
showing the shadow borders on the window. To fix this the opacity has
to be set after the first show. Don't know why this is needed, but it's
probably a bug in the underlying toolkits (maybe GTK or GDK).

It still looks a little jerky the first time the window is drawn.
