### PR TITLE
Coerse shebangs to #!/usr/bin/python2

### DIFF
--- a/usr/bin/mintmenu
+++ b/usr/bin/mintmenu
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 import sys, os
 

--- a/usr/lib/linuxmint/mintMenu/capi.py
+++ b/usr/lib/linuxmint/mintMenu/capi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 import ctypes

--- a/usr/lib/linuxmint/mintMenu/compile.py
+++ b/usr/lib/linuxmint/mintMenu/compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import compileall
 

--- a/usr/lib/linuxmint/mintMenu/keybinding.py
+++ b/usr/lib/linuxmint/mintMenu/keybinding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # -*- coding: utf-8; -*-
 # Copyright (C) 2013  Ozcan Esen <ozcanesen@gmail.com>

--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 gi.require_version("Gtk", "2.0")

--- a/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 

--- a/usr/lib/linuxmint/mintMenu/plugins/__init__.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/python
+#!/usr/bin/python2

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 gi.require_version("Gtk", "2.0")

--- a/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from gi.repository import Gtk, Gdk, GLib
 from gi.repository import Pango

--- a/usr/lib/linuxmint/mintMenu/plugins/easyfiles.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easyfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import os
 import os.path

--- a/usr/lib/linuxmint/mintMenu/plugins/easygsettings.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easygsettings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 
 from gi.repository import Gio

--- a/usr/lib/linuxmint/mintMenu/plugins/execute.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/execute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import os
 

--- a/usr/lib/linuxmint/mintMenu/plugins/filemonitor.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/filemonitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import os
 import os.path

--- a/usr/lib/linuxmint/mintMenu/plugins/get_apt_cache.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/get_apt_cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import apt, sys
 

--- a/usr/lib/linuxmint/mintMenu/plugins/places.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/places.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from gi.repository import Gtk, Gio
 import os

--- a/usr/lib/linuxmint/mintMenu/plugins/recent.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/recent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 gi.require_version("Gtk", "2.0")

--- a/usr/lib/linuxmint/mintMenu/plugins/system_management.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/system_management.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 gi.require_version("Gtk", "2.0")

--- a/usr/lib/linuxmint/mintMenu/pointerMonitor.py
+++ b/usr/lib/linuxmint/mintMenu/pointerMonitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import gi
 gi.require_version("Gtk", "2.0")


### PR DESCRIPTION
Arch Linux's default "python" install points to Python 3, and mintmenu is certainly not compatible with it!

Closes #134.