### PR TITLE
Fallback to ~/.local/share for application edits.

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -115,7 +115,7 @@ def get_system_item_paths():
     if os.environ.has_key('XDG_DATA_DIRS'):
         item_dirs = os.environ['XDG_DATA_DIRS'].split(":")
     else:
-        item_dirs = [os.path.join('usr', 'share')]
+        item_dirs = [os.path.join(os.environ['HOME'], '.local', 'share')]
 
     return item_dirs
 


### PR DESCRIPTION
Taken from downstream MATE Menu: https://bitbucket.org/ubuntu-mate/mate-menu/commits/3de5f1498b79814a6d973b98afc9a9b3e095c5cf

Closes #131.