### PR TITLE
Localized Desktop folder fix

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/places.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/places.py
@@ -181,7 +181,7 @@ class pluginclass( object ):
                 from configobj import ConfigObj
                 config = ConfigObj(home + "/.config/user-dirs.dirs")
                 tmpdesktopDir = config['XDG_DESKTOP_DIR']
-                if os.path.exists(tmpdesktopDir):
+                if os.path.exists(os.path.expandvars(tmpdesktopDir)):
                     desktopDir = tmpdesktopDir
             except Exception, detail:
                 print detail


### PR DESCRIPTION
XDG_DESKTOP_DIR contains environment variable which is not automatically expanded by Python
`XDG_DESKTOP_DIR="$HOME/Bureau"`
We have to use os.path.expandvars