### PR TITLE
Changes to support 64-bit pointers passing the C-python interface.

### DIFF
--- a/usr/lib/linuxmint/mintMenu/keybinding.py
+++ b/usr/lib/linuxmint/mintMenu/keybinding.py
@@ -57,6 +57,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         threading.Thread.__init__ (self)
         self.setDaemon (True)
 
+        gdk.gdk_keymap_get_default.restype = c_void_p
         self.keymap = capi.get_widget (gdk.gdk_keymap_get_default())
         self.display = Display()
         self.screen = self.display.screen()
@@ -92,6 +93,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         count = c_int()
         array = (KeymapKey * 10)()
         keys = cast(array, POINTER(KeymapKey))
+        gdk.gdk_keymap_get_entries_for_keyval.argtypes = [c_void_p, c_uint, c_void_p, c_void_p]
         gdk.gdk_keymap_get_entries_for_keyval(hash(self.keymap), keyval, byref(keys), byref(count))
         return keys[0].keycode
 
@@ -135,6 +137,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         if window is None:
             self.window = self.screen.root
         else:
+            gdk.gdk_x11_drawable_get_xid.argtypes = [c_void_p]
             self.window = self.display.create_resource_object("window", gdk.gdk_x11_drawable_get_xid(hash(window)))
         self.grab(self.keytext)
 

--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -773,6 +773,7 @@ class MenuWin( object ):
         x = c_int()
         y = c_int()
         # Get the dimensions/position of the widgetToAlignWith
+        gdk.gdk_window_get_origin.argtypes = [c_void_p, c_void_p, c_void_p]
         gdk.gdk_window_get_origin(hash(self.applet.window), byref(x), byref(y))
         entryX = x.value
         entryY = y.value

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -275,6 +275,7 @@ class pluginclass( object ):
 
         self.favoritesBox.connect( "drag-data-received", self.ReceiveCallback )
 
+        gtk.gtk_drag_dest_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
         gtk.gtk_drag_dest_set ( hash(self.favoritesBox), Gtk.DestDefaults.MOTION | Gtk.DestDefaults.HIGHLIGHT | Gtk.DestDefaults.DROP,  self.toButton, 2, Gdk.DragAction.COPY )
         self.showFavoritesButton.connect( "drag-data-received", self.ReceiveCallback )
         gtk.gtk_drag_dest_set ( hash(self.showFavoritesButton), Gtk.DestDefaults.MOTION | Gtk.DestDefaults.HIGHLIGHT | Gtk.DestDefaults.DROP, self.toButton, 2, Gdk.DragAction.COPY )
@@ -600,6 +601,7 @@ class pluginclass( object ):
         # of the existing text, that's the most likely candidate anyhow
         self.searchEntry.grab_focus()
         if self.rememberFilter or not clear:
+            gtk.gtk_editable_set_position.argtypes = [c_void_p, c_int]
             gtk.gtk_editable_set_position(hash(self.searchEntry), -1)
         else:
             self.searchEntry.set_text("")
@@ -897,6 +899,7 @@ class pluginclass( object ):
     def keyPress( self, widget, event ):
         if event.string.strip() != "" or event.keyval == Gdk.KEY_BackSpace:
             self.searchEntry.grab_focus()
+            gtk.gtk_editable_set_position.argtypes = [c_void_p, c_int]
             gtk.gtk_editable_set_position(hash(self.searchEntry), -1)
             self.searchEntry.event( event )
             return True
@@ -962,6 +965,7 @@ class pluginclass( object ):
 
                 mTree.show_all()
                 self.mintMenuWin.stopHiding()
+                gtk.gtk_menu_popup.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, c_uint, c_uint]
                 gtk.gtk_menu_popup(hash(mTree), None, None, None, None, ev.button, ev.time)
             else:
                 mTree = Gtk.Menu()
@@ -981,6 +985,7 @@ class pluginclass( object ):
                 insertSpaceMenuItem.connect( "activate", self.onFavoritesInsertSpace, widget, insertBefore )
                 insertSeparatorMenuItem.connect( "activate", self.onFavoritesInsertSeparator, widget, insertBefore )
                 self.mintMenuWin.stopHiding()
+                gtk.gtk_menu_popup.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, c_uint, c_uint]
                 gtk.gtk_menu_popup(hash(mTree), None, None, None, None, ev.button, ev.time)
 
     def menuPopup( self, widget, event ):
@@ -1043,6 +1048,7 @@ class pluginclass( object ):
                 startupMenuItem.connect( "toggled", self.onAddToStartup, widget )
 
             self.mintMenuWin.stopHiding()
+            gtk.gtk_menu_popup.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, c_uint, c_uint]
             gtk.gtk_menu_popup(hash(mTree), None, None, None, None, event.button, event.time)
 
     
@@ -1121,6 +1127,7 @@ class pluginclass( object ):
         menu.show_all()
 
         self.mintMenuWin.stopHiding()
+        gtk.gtk_menu_popup.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, c_uint, c_uint]
         gtk.gtk_menu_popup(hash(menu), None, None, None, None, event.button, event.time)
 
         #menu.attach_to_widget(self.searchButton, None)
@@ -1442,8 +1449,10 @@ class pluginclass( object ):
                     self.favorites.append( favButton )
                     self.favoritesPositionOnGrid( favButton )
                     favButton.connect( "drag-data-received", self.onFavButtonDragReorder )
+                    gtk.gtk_drag_dest_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
                     gtk.gtk_drag_dest_set( hash(favButton), Gtk.DestDefaults.MOTION | Gtk.DestDefaults.HIGHLIGHT | Gtk.DestDefaults.DROP, self.fromFav, 2, Gdk.DragAction.COPY )
                     favButton.connect( "drag-data-get", self.onFavButtonDragReorderGet )
+                    gtk.gtk_drag_source_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
                     gtk.gtk_drag_source_set( hash(favButton), Gdk.ModifierType.BUTTON1_MASK, self.toFav, 3, Gdk.DragAction.COPY )
                     position += 1
 
@@ -1522,8 +1531,10 @@ class pluginclass( object ):
             self.favoritesPositionOnGrid( favButton )
 
             favButton.connect( "drag-data-received", self.onFavButtonDragReorder )
+            gtk.gtk_drag_dest_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
             gtk.gtk_drag_dest_set( hash(favButton), Gtk.DestDefaults.MOTION | Gtk.DestDefaults.HIGHLIGHT | Gtk.DestDefaults.DROP, self.toFav, 3, Gdk.DragAction.COPY )
             favButton.connect( "drag-data-get", self.onFavButtonDragReorderGet )
+            gtk.gtk_drag_source_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
             gtk.gtk_drag_source_set ( hash(favButton), Gdk.ModifierType.BUTTON1_MASK, self.toFav, 3, Gdk.DragAction.COPY )
 
             if position >= 0:

--- a/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
@@ -273,12 +273,14 @@ class ApplicationLauncher( easyButton ):
 
         array = TargetEntry * 2
         targets = array(( "text/plain", 0, 100 ), ( "text/uri-list", 0, 101 ))
+        gtk.gtk_drag_source_set.argtypes = [c_void_p, c_ushort, c_void_p, c_int, c_ushort]
         gtk.gtk_drag_source_set(hash(self), Gdk.ModifierType.BUTTON1_MASK, targets, 2, Gdk.DragAction.COPY)
 
         icon = self.getIcon( Gtk.IconSize.DND )
         if icon:
             iconName, s = icon.get_icon_name()
             c = c_char_p(iconName.decode('utf-8', 'ignore').encode('ascii', 'ignore'))
+            gtk.gtk_drag_source_set_icon_name.argtypes = [c_void_p, c_char_p]
             gtk.gtk_drag_source_set_icon_name( hash(self), c)
 
         self.connectSelf( "focus-in-event", self.onFocusIn )
@@ -397,6 +399,7 @@ class ApplicationLauncher( easyButton ):
         if icon:
             iconName, size = icon.get_icon_name()
             c = c_char_p(iconName.encode('ascii', 'ignore'))
+            gtk.gtk_drag_source_set_icon_name.argtypes = [c_void_p, c_char_p]
             gtk.gtk_drag_source_set_icon_name( hash(self), c)
 
     def startupFileChanged( self, *args ):

--- a/usr/lib/linuxmint/mintMenu/plugins/places.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/places.py
@@ -263,6 +263,7 @@ class pluginclass( object ):
             trashMenu.show_all()
             emptyTrashMenuItem.connect ( "activate", self.emptyTrash, widget )
             self.mintMenuWin.stopHiding()
+            gtk.gtk_menu_popup.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, c_uint, c_uint]
             gtk.gtk_menu_popup(hash(trashMenu), None, None, None, None, 3, 0)
 
     def emptyTrash( self, menu, widget):

--- a/usr/lib/linuxmint/mintMenu/pointerMonitor.py
+++ b/usr/lib/linuxmint/mintMenu/pointerMonitor.py
@@ -28,6 +28,7 @@ class PointerMonitor(GObject.GObject, threading.Thread):
         
     # Receives GDK windows
     def addWindowToMonitor(self, window):
+        gdk.gdk_x11_drawable_get_xid.argtypes = [c_void_p]
         xWindow = self.display.create_resource_object("window", gdk.gdk_x11_drawable_get_xid(hash(window)))
         self.windows.append(xWindow)
             


### PR DESCRIPTION
This fixes recent problems encountered on systems using python2
compiled with the PIE option set.

This fixes issue #137.

On ArchLinux, Python2 version 2.7.10 was packaged with a make_depedency on hardening-wrapper.  This turned on PIE.  With this option, it was far more likely that addresses and pointers would surpass the 32-bit boundary.  The vanilla behavior of python2 ctypes uses 32-bit by default.  This essentially truncates/corrupts all addresses/pointers crossing from C to Python (return result) or from Python to C (arguments).  ctypes can support this.  But you have to explicitly tell it to do so.