### PR TITLE
Reload settings if applet icon does not exist

### DIFF
--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -578,6 +578,12 @@ class MenuWin( object ):
         self.buttonText =  self.settings.get_string("applet-text")
         self.theme_name =  self.settings.get_string( "theme-name" )
         self.hotkeyText =  self.settings.get_string( "hot-key" )
+
+        # If applet-icon does not exist fall back to default or else menu wont start
+        if not os.path.exists( self.settings.get_string( "applet-icon" ) ):
+            os.system( "gsettings reset com.linuxmint.mintmenu applet-icon" )
+            self.settings = Gio.Settings.new( "com.linuxmint.mintmenu" )
+
         self.buttonIcon =  self.settings.get_string( "applet-icon" )
         self.iconSize = self.settings.get_int( "applet-icon-size" )
 


### PR DESCRIPTION
https://github.com/linuxmint/mintmenu/issues/157 I tested and reproduced this one, and I have composed a fix for it. On mintmenu startup, if the applet icon is not found, instead of crashing by using an image that does not exist, the default setting for applet icon is restored and loaded. 