### PR TITLE
Fix windows-key global keybinding.

### DIFF
--- a/usr/lib/linuxmint/mintMenu/keybinding.py
+++ b/usr/lib/linuxmint/mintMenu/keybinding.py
@@ -89,7 +89,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         catch = error.CatchError(error.BadAccess)
         for ignored_mask in self.ignored_masks:
             mod = modifiers | ignored_mask
-            result = self.window.grab_key(self.keycode, mod, True, X.GrabModeAsync, X.GrabModeSync, onerror=catch)
+            result = self.window.grab_key(self.keycode, mod, True, X.GrabModeAsync, X.GrabModeAsync, onerror=catch)
         self.display.flush()
         # sync has been blocking. Don't know why.
         #self.display.sync()
@@ -146,7 +146,9 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
                         GLib.idle_add(self.idle)
                     self.display.allow_events(X.AsyncKeyboard, event.time)
                 else:
+                    self.display.send_event(self.window, event, X.KeyPressMask | X.KeyReleaseMask, True)
                     self.display.allow_events(X.ReplayKeyboard, event.time)
+                    wait_for_release = False
             except AttributeError:
                 continue
 


### PR DESCRIPTION
This fixes #98 where setting the windows-key as the menu hotkey blocks all other windows-key-based shortcuts.

Caveat: I use Ubuntu MATE, rather than Linux Mint, but the fix there worked in the same way. Please double-check that this doesn't break anything else on your systems when using a different desktop environment.