### PR TITLE
safe apt search with shell escapes

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -18,6 +18,7 @@ from execute import Execute
 from easygsettings import EasyGSettings
 from easyfiles import *
 import recentHelper as RecentHelper
+import pipes
 
 import matemenu
 
@@ -637,7 +638,7 @@ class pluginclass( object ):
             keywords = keyword.split(" ")
             command = "cat %(home)s/.linuxmint/mintMenu/apt.cache" % {'home':home}
             for word in keywords:
-                command = "%(command)s | grep %(word)s" % {'command':command, 'word':word}
+                command = "%(command)s | grep %(word)s" % {'command':command, 'word':pipes.quote(word)}
             pkgs = commands.getoutput(command)
             pkgs = pkgs.split("\n")
             num_pkg_found = 0


### PR DESCRIPTION
This fixes #178.

add_apt_filter_results ran a command with keywords from the menu's Search entry without shell escaping. This made it possible to have it run shell commands by using command substitution. E.g. searching for `$(xeyes)` would run xeyes.

When/if mintmenu gets ported to Python3 pipes.quote should be replaced by shlex.quote.