### PR TITLE
Highlight previous search so typing overwrites it

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -503,7 +503,6 @@ class pluginclass( object ):
         else:
             self.changeTab( 1 )
 
-        self.searchEntry.select_region( 0, -1 )
         if self.rememberFilter and self.searchEntry.get_text().strip() != "":
             self.Filter(self.activeFilter[2], self.activeFilter[1])
 
@@ -546,6 +545,7 @@ class pluginclass( object ):
         self.searchEntry.grab_focus()
         if self.rememberFilter or not clear:
             self.searchEntry.set_position(-1)
+            self.searchEntry.select_region( 0, -1 )
         else:
             self.searchEntry.set_text("")
 

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -544,7 +544,6 @@ class pluginclass( object ):
         # of the existing text, that's the most likely candidate anyhow
         self.searchEntry.grab_focus()
         if self.rememberFilter or not clear:
-            self.searchEntry.set_position(-1)
             self.searchEntry.select_region( 0, -1 )
         else:
             self.searchEntry.set_text("")


### PR DESCRIPTION
When set to remember the last search, on next opening the menu it would display the last search and put the cursor at the end of it. If you wanted to do a new search you would first have to delete your previous search. More convenient if you starting typing it overwrites the last search and only if you place the cursor with arrow keys or mouse it switches to insert / append text to the last search.

There was existing code that did in fact do that but it was in the wrong place. This patch puts it in the right place. Fixes #86.