### PR TITLE
[WIP] Add execute/file open functionality to search entry

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Depends:
  gir1.2-gtk-3.0,
  gir1.2-mate-desktop,
  mozo
+Recommends: gir1.2-vte-2.91
 Description: Advanced MATE menu
  One of the most advanced menus under Linux. MintMenu supports filtering,
  favorites, easy-uninstallation, autosession, and many other features.

--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -471,7 +471,7 @@ class MenuWin(object):
             self.keybinder.connect("activate", self.onBindingPress)
             self.keybinder.start()
             self.settings.connect("changed::hot-key", self.hotkeyChanged)
-            print("Binding to Hot Key: %s" % self.hotkeyText)
+            # print("Binding to Hot Key: %s" % self.hotkeyText)
         except Exception as e:
             self.keybinder = None
             print("** WARNING ** - Keybinder Error")

--- a/usr/lib/linuxmint/mintMenu/mintMenuConfig.glade
+++ b/usr/lib/linuxmint/mintMenu/mintMenuConfig.glade
@@ -12,6 +12,18 @@
     <property name="value">1</property>
     <property name="step_increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment11">
+    <property name="lower">200</property>
+    <property name="upper">10000</property>
+    <property name="value">600</property>
+    <property name="step_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment12">
+    <property name="lower">200</property>
+    <property name="upper">10000</property>
+    <property name="value">500</property>
+    <property name="step_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -750,8 +762,8 @@
                     <property name="margin_left">7</property>
                     <property name="margin_right">7</property>
                     <property name="margin_bottom">7</property>
-                    <property name="row_spacing">5</property>
-                    <property name="column_spacing">2</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">12</property>
                     <child>
                       <object class="GtkCheckButton" id="showAppComments">
                         <property name="label" translatable="yes">Show application comments</property>
@@ -759,8 +771,8 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="halign">start</property>
                         <property name="margin_top">11</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -776,7 +788,7 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -787,12 +799,12 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="hover">
-                        <property name="label" translatable="yes">Hover</property>
+                        <property name="label" translatable="yes">Open categories on hover</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -823,7 +835,7 @@
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
                         <property name="adjustment">adjustment4</property>
-                        <property name="value">100</property>
+                        <property name="value">99.999999999776477</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -893,7 +905,7 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -909,7 +921,7 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -925,12 +937,107 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
                         <property name="top_attach">8</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="allow-execute">
+                        <property name="label" translatable="yes">Enable run/open features for search entry</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">9</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="integrated-terminal-height">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="invisible_char">●</property>
+                        <property name="text">500</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="secondary_icon_activatable">False</property>
+                        <property name="adjustment">adjustment12</property>
+                        <property name="value">500</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">12</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="integrated-terminal-width">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="invisible_char">●</property>
+                        <property name="text">600</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="secondary_icon_activatable">False</property>
+                        <property name="adjustment">adjustment11</property>
+                        <property name="value">600</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="integrated-terminal-height-label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">18</property>
+                        <property name="label" translatable="yes">Output/terminal height (pixels):</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">12</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="integrated-terminal-width-label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">18</property>
+                        <property name="label" translatable="yes">Output/terminal width (pixels):</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="integrated-terminal-enabled">
+                        <property name="label" translatable="yes">Enable integrated terminal</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">18</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">10</property>
                         <property name="width">2</property>
                       </packing>
                     </child>

--- a/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
@@ -134,6 +134,16 @@ class mintMenuConfig(object):
         self.bindGSettingsValueToWidget(self.settingsApplications, "bool", "remember-filter", self.rememberFilter, "toggled", self.rememberFilter.set_active, self.rememberFilter.get_active)
         self.bindGSettingsValueToWidget(self.settingsApplications, "bool", "enable-internet-search", self.enableInternetSearch, "toggled", self.enableInternetSearch.set_active,  self.enableInternetSearch.get_active)
 
+        self.allow_execute = self.builder.get_object("allow-execute")
+        self.integrated_terminal_enabled = self.builder.get_object("integrated-terminal-enabled")
+        self.integrated_terminal_width = self.builder.get_object("integrated-terminal-width")
+        self.integrated_terminal_height = self.builder.get_object("integrated-terminal-height")
+
+        self.bindGSettingsValueToWidget(self.settingsApplications, "bool", "allow-execute", self.allow_execute, "toggled", self.allow_execute.set_active,  self.allow_execute.get_active)
+        self.bindGSettingsValueToWidget(self.settingsApplications, "bool", "integrated-terminal-enabled", self.integrated_terminal_enabled, "toggled", self.integrated_terminal_enabled.set_active,  self.integrated_terminal_enabled.get_active)
+        self.bindGSettingsValueToWidget(self.settingsApplications, "int", "integrated-terminal-width", self.integrated_terminal_width, "value-changed", self.integrated_terminal_width.set_value,  self.integrated_terminal_width.get_value)
+        self.bindGSettingsValueToWidget(self.settingsApplications, "int", "integrated-terminal-height", self.integrated_terminal_height, "value-changed", self.integrated_terminal_height.set_value,  self.integrated_terminal_height.get_value)
+
         self.bindGSettingsValueToWidget(self.settingsPlaces, "int", "icon-size", self.placesIconSize, "value-changed", self.placesIconSize.set_value, self.placesIconSize.get_value)
         self.bindGSettingsValueToWidget(self.settingsSystem, "int", "icon-size", self.systemIconSize, "value-changed", self.systemIconSize.set_value, self.systemIconSize.get_value)
 

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.glade
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.18"/>
   <object class="GtkWindow" id="mainWindow">
     <property name="width_request">169</property>
     <property name="height_request">227</property>
@@ -44,8 +44,10 @@
                           <object class="GtkLabel" id="label6">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xpad">15</property>
-                            <property name="ypad">10</property>
+                            <property name="margin_left">15</property>
+                            <property name="margin_right">15</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_bottom">10</property>
                             <property name="label" translatable="yes">Favorites</property>
                             <property name="use_markup">True</property>
                             <property name="xalign">0</property>
@@ -186,8 +188,10 @@
                           <object class="GtkLabel" id="label2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xpad">15</property>
-                            <property name="ypad">10</property>
+                            <property name="margin_left">15</property>
+                            <property name="margin_right">15</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_bottom">10</property>
                             <property name="label" translatable="yes">Applications</property>
                             <property name="xalign">0</property>
                           </object>

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.glade
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.glade
@@ -363,22 +363,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkLabel" id="searchLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Search/Run:</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">5</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkEntry" id="searchEntry">
                     <property name="height_request">25</property>
                     <property name="visible">True</property>

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.glade
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.glade
@@ -362,7 +362,7 @@
                   <object class="GtkLabel" id="searchLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Search</property>
+                    <property name="label" translatable="yes">Search/Run:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -394,6 +394,33 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkButton" id="executeButton">
+                    <property name="width_request">28</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Try to execute or open your entry</property>
+                    <property name="relief">none</property>
+                    <child>
+                      <object class="GtkImage" id="image2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="can_default">True</property>
+                        <property name="has_default">True</property>
+                        <property name="stock">gtk-execute</property>
+                        <property name="icon_size">1</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkButton" id="searchButton">
                     <property name="width_request">28</property>
                     <property name="visible">True</property>
@@ -420,7 +447,7 @@
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="pack_type">end</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -203,7 +203,7 @@ class pluginclass(object):
         self.categoriesBox = self.builder.get_object("categoriesBox")
         self.favoritesBox = self.builder.get_object("favoritesBox")
         self.applicationsScrolledWindow = self.builder.get_object("applicationsScrolledWindow")
-
+        self.headingstocolor = [self.builder.get_object("label6"), self.builder.get_object("label2")]
         self.numApps = 0
 
         # These properties are NECESSARY to maintain consistency

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -299,7 +299,6 @@ class pluginclass(object):
 
         self.builder.get_object("searchButton").connect("button-press-event", self.searchPopup)
         self.builder.get_object("executeButton").connect("button-press-event", self.on_execute_button_pressed)
-        self.update_allow_execute()
 
         # self.icon_theme = Gtk.IconTheme.get_default()
         # self.icon_theme.connect("changed", self.on_icon_theme_changed)
@@ -411,16 +410,7 @@ class pluginclass(object):
     def update_allow_execute(self, settings=None, key=None, args=None):
         if settings and key:
             self.allow_execute = settings.get_boolean(key)
-        #self.builder.get_object("executeButton").set_visible(self.allow_execute)
-        if self.allow_execute:
-            self.builder.get_object("executeButton").show()
-            searchLabel_text = _("Search/Run:")
-        else:
-            self.builder.get_object("executeButton").hide()
-            searchLabel_text = _("Search:")
-        searchLabel = self.builder.get_object("searchLabel")
-        searchLabel.set_text(searchLabel_text)
-        searchLabel.show()
+        self.builder.get_object("executeButton").set_visible(self.allow_execute)
 
     def changeShowApplicationComments(self, settings, key, args):
         self.showapplicationcomments = settings.get_boolean(key)

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -654,13 +654,16 @@ class pluginclass(object):
             return
         commands = user_text.split()
         cmd = self.verify_command(commands[0])
-        if cmd:
-            text = "<b>%s</b>" % cgi.escape(text)
-            commands[0] = cmd
-            if cmd.startswith("xdg-open"):
-                self.add_suggestion("document-open", _("Try to open %s") % text, None, self.execute_user_input, commands, False)
-            else:
-                self.add_suggestion("application-x-executable", _("Run %s") % text, None, self.execute_user_input, commands, False)
+        if not cmd:
+            return
+        text = "<b>%s</b>" % cgi.escape(text)
+        commands[0] = cmd
+        if cmd.startswith("xdg-open"):
+            self.add_suggestion("document-open", _("Try to open %s") % text,
+                                None, self.execute_user_input, commands, False)
+        else:
+            self.add_suggestion("application-x-executable", _("Run %s") % text,
+                                None, self.execute_user_input, commands, False)
         self.applicationsBox.get_children()[-1].grab_focus()
 
     def add_apt_filter_results(self, keyword):
@@ -1086,10 +1089,9 @@ class pluginclass(object):
             if hasVte and self.integrated_terminal_enabled:
                 try:
                     IntegratedTerminal(command,
-                        _("mintMenu Integrated Terminal"),
-                        width=self.integrated_terminal_width,
-                        height=self.integrated_terminal_height
-                        )
+                                       _("mintMenu Integrated Terminal"),
+                                       width=self.integrated_terminal_width,
+                                       height=self.integrated_terminal_height)
                 except Exception as e:
                     print("IntegratedTerminal exception:", e)
                     hasVte = False

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -419,7 +419,7 @@ class pluginclass(object):
             self.builder.get_object("executeButton").hide()
             searchLabel_text = _("Search:")
         searchLabel = self.builder.get_object("searchLabel")
-        searchLabel.set_markup("<b>%s</b>" % searchLabel_text)
+        searchLabel.set_text(searchLabel_text)
         searchLabel.show()
 
     def changeShowApplicationComments(self, settings, key, args):
@@ -800,16 +800,21 @@ class pluginclass(object):
                             shownList.append(i)
                             #if this is the first matching item
                             #focus it
-                            if(not showns):
+                            if not showns:
                                 i.grab_focus()
                             showns = True
-                if not showns:
-                    if len(text) >= 3:
-                        self.add_search_suggestions(text)
-                        if self.allow_execute:
-                            GLib.timeout_add(150, self.add_execute_suggestions, text)
-                        if self.useAPT:
-                            GLib.timeout_add(300, self.add_apt_filter_results, text)
+                textlen = len(text)
+                if self.allow_execute and textlen:
+                    if showns:
+                        dupes = [True for item in shownList if item.appExec.split().pop(0) == text]
+                    else:
+                        dupes = None
+                    if not dupes:
+                        GLib.timeout_add(150, self.add_execute_suggestions, text)
+                if not showns and textlen > 2:
+                    self.add_search_suggestions(text)
+                    if self.useAPT:
+                        GLib.timeout_add(300, self.add_apt_filter_results, text)
 
                 for i in self.categoriesBox.get_children():
                     i.released()
@@ -856,6 +861,7 @@ class pluginclass(object):
             event.keyval == Gdk.KEY_Return:
             self.on_execute_button_pressed(widget, event)
             return True
+
         return False
 
     def favPopup(self, widget, event):

--- a/usr/lib/linuxmint/mintMenu/plugins/terminal.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/terminal.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version('Vte', '2.91')
+from gi.repository import Gtk, Gdk, GLib, Vte
+
+class IntegratedTerminal(Gtk.Window):
+
+    def __init__(self, command, title=None, shell=None, cwd=None, width=600, height=500):
+        try:
+            self.terminal=Vte.Terminal()
+            self.terminal.set_scrollback_lines(-1)
+            # Setting the font doesn't work for some reason, let's leave it
+            # self.terminal.set_font(Pango.FontDescription(string='Monospace'))
+            self.command = command
+            self.ready = False
+            self.output_handler = self.terminal.connect("cursor-moved",
+                self.on_cursor_moved)
+            # apparently Vte.Terminal.spawn_sync() is deprecated in favour of the
+            # non-existent Vte.Terminal.spawn_async()...
+            self.terminal.spawn_sync(
+                    Vte.PtyFlags.DEFAULT, # pty_flags
+                    cwd or os.environ.get("HOME"), # working_directory
+                    shell or [os.environ.get("SHELL")], # argv
+                    [], # envv
+                    GLib.SpawnFlags.DO_NOT_REAP_CHILD, # spawn_flags
+                    None, # child_setup
+                    None, # child_setup_data
+                    None # cancellable
+                    )
+        except Exception as e:
+            self.close()
+            raise Exception(e)
+
+        Gtk.Window.__init__(self, title=title or "mintMenu Integrated Terminal")
+        self.set_icon_name("utilities-terminal")
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.scrolled_window = Gtk.ScrolledWindow()
+        self.scrolled_window.set_hexpand(True)
+        self.scrolled_window.set_vexpand(True)
+        self.scrolled_window.set_size_request(width, height)
+        self.scrolled_window.add(self.terminal)
+        box.pack_start(self.scrolled_window, False, True, 0)
+        self.add(box)
+        self.connect("key-press-event", self.on_key_press_event)
+        self.terminal.connect("child-exited", self.exit)
+        self.terminal.connect("eof", self.exit)
+        self.terminal.set_rewrap_on_resize(True)
+
+    def on_cursor_moved(self, terminal):
+        if not self.ready:
+            # we have to run the command on a callback because the
+            # spawn_sync() method doesn't wait for the shell to load,
+            # so instead we have to wait for the shell to create a prompt
+            self.ready = True
+            # if we don't show the terminal once after this it won't
+            # always receive output, so we show it and hide it again right
+            # away. Whatever works...
+            self.show_all()
+            self.hide()
+            # Now we can go:
+            command = "%s\n" % self.command
+            self.terminal.feed_child(command, len(command))
+            return
+        # Unfortunately we cannot guarantee that the command is on the first
+        # line (the shell may display somethinge else first), so we have to
+        # search for it:
+        x, y = terminal.get_cursor_position()
+        contents, dummy = terminal.get_text_range(0, 0, x, y, None, None)
+        lines = contents.split("\n")
+        prefix = ""
+        command_found = False
+        for line in lines:
+            if not line:
+                continue
+            if command_found:
+                if not line.lstrip(prefix):
+                    # we got a command prompt, exit
+                    self.exit()
+                    break
+                # the command generated output, show the terminal
+                terminal.disconnect(self.output_handler)
+                self.show_all()
+                break
+            if self.command in line:
+                # this is our command line
+                prefix = line.split(self.command, 1)[0]
+                command_found = True
+
+    def on_key_press_event(self, widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            self.exit()
+
+    def exit(self, *args):
+        # Gtk.main_quit()
+        self.close()

--- a/usr/lib/linuxmint/mintMenu/plugins/terminal.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/terminal.py
@@ -19,9 +19,9 @@ class IntegratedTerminal(Gtk.Window):
             self.command = command
             self.ready = False
             self.output_handler = self.terminal.connect("cursor-moved",
-                self.on_cursor_moved)
-            # apparently Vte.Terminal.spawn_sync() is deprecated in favour of the
-            # non-existent Vte.Terminal.spawn_async()...
+                                                        self.on_cursor_moved)
+            # apparently Vte.Terminal.spawn_sync() is deprecated in favour of
+            # the non-existent Vte.Terminal.spawn_async()...
             self.terminal.spawn_sync(
                     Vte.PtyFlags.DEFAULT, # pty_flags
                     cwd or os.environ.get("HOME"), # working_directory
@@ -81,11 +81,11 @@ class IntegratedTerminal(Gtk.Window):
                 if not line.lstrip(prefix):
                     # we got a command prompt, exit
                     self.exit()
-                    break
+                    return
                 # the command generated output, show the terminal
                 terminal.disconnect(self.output_handler)
                 self.show_all()
-                break
+                return
             if self.command in line:
                 # this is our command line
                 prefix = line.split(self.command, 1)[0]

--- a/usr/share/glib-2.0/schemas/com.linuxmint.mintmenu.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.mintmenu.gschema.xml
@@ -307,6 +307,28 @@
       <summary></summary>
       <description></description>
     </key>
+
+    <key type="b" name="allow-execute">
+      <default>true</default>
+      <summary></summary>
+      <description></description>
+    </key>
+    <key type="b" name="integrated-terminal-enabled">
+      <default>true</default>
+      <summary></summary>
+      <description></description>
+    </key>
+    <key type="i" name="integrated-terminal-width">
+      <default>600</default>
+      <summary></summary>
+      <description></description>
+    </key>
+
+    <key type="i" name="integrated-terminal-height">
+      <default>500</default>
+      <summary></summary>
+      <description></description>
+    </key>
   </schema>
 
   <schema id="com.linuxmint.mintmenu.plugins.system_management" path="/com/linuxmint/mintmenu/plugins/system_management/">


### PR DESCRIPTION
Probably my new favourite feature, this lets you run applications from the search input.

As long as you enter something that equals a file in your PATH or your home directory (or you may provide the full path), a respective entry is added to search suggestions and receives default input, so you can run it with Enter. If the target file is not executable it gets passed to xdg-open to try to open it instead. 

The search suggestion is not shown if the command entered equals the command in an existing menu entry.

Command line parameters are supported, and unlike the Alt+F2 command line, default shell variables and `~` are fully supported as well. 

With the Integrated terminal option enabled, it runs commands via a Gtk.Vte terminal but only shows it where needed. Beautiful Vte bugs to be worked around included... Otherwise it runs commands through subprocess and popups up a window showing the output if there was any.