### PR TITLE
Preferences: Fix keybind widget alignment on main button tab

### DIFF
--- a/usr/lib/linuxmint/mintMenu/keybinding.py
+++ b/usr/lib/linuxmint/mintMenu/keybinding.py
@@ -162,19 +162,14 @@ class KeybindingWidget(Gtk.Box):
     __gsignals__ = {
         'accel-edited': (GObject.SignalFlags.RUN_LAST, None, ()),
     }
-    def __init__(self, desc):
+    def __init__(self):
         super(KeybindingWidget, self).__init__()
-        self.desc = desc
-        self.label = Gtk.Label(desc)
-        if self.desc != "":
-            self.pack_start(self.label, False, False, 0)
         self.button = Gtk.Button()
         self.button.set_tooltip_text(_("Click to set a new accelerator key for opening and closing the menu.  ") +
                                      _("Press Escape or click again to cancel the operation.  ") +
                                      _("Press Backspace to clear the existing keybinding."))
         self.button.connect("clicked", self.clicked)
-        self.button.set_size_request(200, -1)
-        self.pack_start(self.button, False, False, 4)
+        self.pack_start(self.button, True, True, 0)
 
         self.show_all()
         self.event_id = None

--- a/usr/lib/linuxmint/mintMenu/mintMenuConfig.glade
+++ b/usr/lib/linuxmint/mintMenu/mintMenuConfig.glade
@@ -377,18 +377,6 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Button icon:</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkBox" id="hbox4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -419,11 +407,32 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">2</property>
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkLabel" id="label4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Button icon:</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="keybinding_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Keyboard shortcut:</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
                     </child>
                     <child>
                       <placeholder/>

--- a/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenuConfig.py
@@ -64,9 +64,11 @@ class mintMenuConfig(object):
         self.showButtonIcon = self.builder.get_object("showButtonIcon")
         self.enableInternetSearch = self.builder.get_object("enableInternetSearch")
         self.buttonText = self.builder.get_object("buttonText")
-        self.hotkeyWidget = keybinding.KeybindingWidget(_("Keyboard shortcut:"))
-        grid = self.builder.get_object("main_grid")
-        grid.attach(self.hotkeyWidget, 0, 2, 2, 1)
+        self.hotkeyWidget = keybinding.KeybindingWidget()
+        self.builder.get_object("main_grid").attach_next_to(
+                self.hotkeyWidget,
+                self.builder.get_object("keybinding_label"),
+                Gtk.PositionType.RIGHT, 1, 1)
         self.buttonIcon = self.builder.get_object("buttonIcon")
         self.buttonIconChooser = self.builder.get_object("button_icon_chooser")
         self.image_filter = Gtk.FileFilter()


### PR DESCRIPTION
This involves code changes because it was actually done in code. I moved the label into the .glade and left only the button in code because it was simpler due to related code, but fixed the implementation.