### PR TITLE
Applications: Apply "Always start with favorites pane" option both ways

### DIFF
--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -400,6 +400,8 @@ class MainWindow(object):
         if "applications" in self.plugins and hasattr(self.plugins["applications"], "focusSearchEntry"):
             if self.startWithFavorites:
                 self.plugins["applications"].changeTab(0)
+            else:
+                self.plugins["applications"].changeTab(1)
             self.plugins["applications"].focusSearchEntry()
 
     def hide(self):


### PR DESCRIPTION
Currently only the enabled option forces the Favorites pane. This change makes it so the disabled option forces the Applications pane instead to be consistent.