### PR TITLE
Applications: Categories column always use natural width

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/applications.glade
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.glade
@@ -265,7 +265,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow1">
+                          <object class="GtkScrolledWindow" id="categoriesScrolledWindow">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">never</property>

--- a/usr/lib/linuxmint/mintMenu/plugins/applications.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/applications.py
@@ -247,8 +247,13 @@ class pluginclass(object):
         self.favorites = []
 
         self.content_holder.set_size_request(self.width, self.height)
-        self.categoriesBox.set_size_request(self.width / 3, -1)
-        self.applicationsBox.set_size_request(self.width / 2, -1)
+        # Calculate applicationsBox width based on categoryBox width, but since
+        # we won't have that until the menu has been shown go with an estimate
+        self.applicationsBox.set_size_request(self.width - 155, -1)
+        # Add margin for scrollbars to categoriesBox
+        categoriesScrolledWindow = self.builder.get_object("categoriesScrolledWindow")
+        scrollbar_width = categoriesScrolledWindow.get_vscrollbar().get_preferred_width()
+        self.categoriesBox.set_margin_right(scrollbar_width.natural_width + 2)
 
         self.buildingButtonList = False
         self.stopBuildingButtonList = False
@@ -327,9 +332,7 @@ class pluginclass(object):
     def changePluginSize(self, settings, key, args):
         if key == "width":
             self.width = settings.get_int(key)
-            self.categoriesBox.set_size_request(self.width / 3, -1)
-            self.applicationsBox.set_size_request(self.width / 2, -1)
-
+            self.applicationsBox.set_size_request(self.width - self.categoriesBox.get_preferred_width().natural_width, -1)
         elif key == "height":
             self.heigth = settings.get_int(key)
         self.content_holder.set_size_request(self.width, self.height)

--- a/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
@@ -101,12 +101,14 @@ GObject.type_register(IconManager)
 
 class easyButton(Gtk.Button):
 
-    def __init__(self, iconName, iconSize, labels = None, buttonWidth = -1, buttonHeight = -1):
+    def __init__(self, iconName, iconSize, labels=None, buttonWidth=-1,
+                 buttonHeight=-1, ellipsis=True):
         GObject.GObject.__init__(self)
         self.connections = []
         self.iconName = iconName
         self.iconSize = iconSize
         self.showIcon = True
+        self.ellipsis = ellipsis
 
         self.set_relief(Gtk.ReliefStyle.NONE)
         self.set_size_request(buttonWidth, buttonHeight)
@@ -170,7 +172,8 @@ class easyButton(Gtk.Button):
                 labelStyle.insert(attr)
             label.set_attributes(labelStyle)
 
-        label.set_ellipsize(Pango.EllipsizeMode.END)
+        if self.ellipsis:
+            label.set_ellipsize(Pango.EllipsizeMode.END)
         label.set_alignment(0.0, 1.0)
         label.set_max_width_chars(0)
         label.show()
@@ -521,7 +524,7 @@ class FavApplicationLauncher(ApplicationLauncher):
 class CategoryButton(easyButton):
 
     def __init__(self, iconName, iconSize, labels , f):
-        easyButton.__init__(self, iconName, iconSize, labels)
+        easyButton.__init__(self, iconName, iconSize, labels, ellipsis=False)
         self.filter = f
 
 iconManager = IconManager()


### PR DESCRIPTION
Currently the width is 1/3 of the plugin's total width, which can lead to a lot of wasted space depending on the configured total width.
