### PR TITLE
Fix preferences not launching

### DIFF
--- a/usr/lib/linuxmint/mintMenu/mintMenu.py
+++ b/usr/lib/linuxmint/mintMenu/mintMenu.py
@@ -667,7 +667,7 @@ class MenuWin(object):
         about.show()
 
     def showPreferences(self, action, userdata = None):
-        Execute("/usr/lib/linuxmint/mintMenu/preferences.py")
+        Execute("python2 /usr/lib/linuxmint/mintMenu/preferences.py")
 
     def showMenuEditor(self, action, userdata = None):
         Execute("mozo")


### PR DESCRIPTION
Was trying to run with python3 instead of python2
Fixes https://github.com/linuxmint/mint19.2-beta/issues/3