### PR TITLE
plugins: fix number of callback arguments

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/places.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/places.py
@@ -74,7 +74,7 @@ class pluginclass(object):
         if self.showtrash:
             self.refreshTrash()
 
-    def changePluginSize(self, settings, key, args = None):
+    def changePluginSize(self, settings, key):
         self.allowScrollbar = self.settings.get_boolean("allow-scrollbar")
         self.width = self.settings.get_int("width")
         if not self.allowScrollbar:

--- a/usr/lib/linuxmint/mintMenu/plugins/system_management.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/system_management.py
@@ -65,7 +65,7 @@ class pluginclass(object):
     def wake(self):
         pass
 
-    def changePluginSize(self, settings, key, args):
+    def changePluginSize(self, settings, key):
         self.allowScrollbar = self.settings.get_boolean("allow-scrollbar")
         if key == "width":
             self.width = settings.get_int(key)


### PR DESCRIPTION
fixes runtime warning:
TypeError: changePluginSize() takes exactly 4 arguments (3 given)

looks like it was overlooked in https://github.com/linuxmint/mintmenu/commit/66f76df4d31488caa178d053dc53d52f29dca43d