### PR TITLE
Fix launching of pkexec applications

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/easybuttons.py
@@ -349,7 +349,12 @@ class ApplicationLauncher(easyButton):
                     cmd = "mate-terminal -e \"" + self.appExec + "\""
                 Execute(cmd, self.appPath)
             else:
-                Execute(None, desktopFile=self.desktopFile)
+                if self.appExec.startswith("pkexec "):
+                    print ("Using pkexec workaround...")
+                    cmd = "sh -c \"" + self.appExec + "\""
+                    Execute(cmd, self.appPath)
+                else:
+                    Execute(None, desktopFile=self.desktopFile)
 
     def uninstall(self, *args):
         Execute("mint-remove-application " + self.desktopFile)


### PR DESCRIPTION
When launching mintsources, timeshift or an app which Exec field (in the desktop file)
starts with pkexec, nothing happens and the output states:

"Refusing to render service to dead parents."

For some reason this does not happen on fresh LMDE 4 and Mint 19.3 installations,
but it happens on LMDE 3 -> LMDE 4 and 19.1 -> 19.3 upgrades.

Similar bugs were fixed in nemo and cinnamon. Pkexec is known to cause issues
depending on how it's launched.

This introduces a workaround to wrap the pkexec call within an "sh -c".