### PR TITLE
Fix launching pkexec applications

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/execute.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/execute.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python2
 
 import os
-from gi.repository import Gio
+from gi.repository import Gio, GLib
 
 
 def RemoveArgs(Execline):
@@ -16,12 +16,20 @@ def RemoveArgs(Execline):
 
     return Execline
 
+def dummy_child_watch (pid, status, data):
+  # Do nothing, this is just to ensure we don't double fork
+  # and break pkexec: https://bugzilla.gnome.org/show_bug.cgi?id=675789
+  pass
+
+def gather_pid_callback(appinfo, pid, data):
+    GLib.child_watch_add(pid, dummy_child_watch, None)
+
 # Actually execute the command
 def Execute(cmd , commandCwd=None, desktopFile=None):
     if desktopFile:
         launcher = Gio.DesktopAppInfo.new_from_filename(desktopFile)
-        retval = launcher.launch_uris()
-
+        retval = launcher.launch_uris_as_manager(uris=[], launch_context=None, spawn_flags=GLib.SpawnFlags.SEARCH_PATH|GLib.SpawnFlags.DO_NOT_REAP_CHILD, \
+            user_setup=None, user_setup_data=None, pid_callback=gather_pid_callback, pid_callback_data=None)
         return retval
 
     cwd = os.path.expanduser("~")


### PR DESCRIPTION
When launching mintsources, timeshift or an app which Exec field (in the desktop file)
starts with pkexec, nothing happens and the output states:

"Refusing to render service to dead parents."

For some reason this does not happen on fresh LMDE 4 and Mint 19.3 installations,
but it happens on LMDE 3 -> LMDE 4 and 19.1 -> 19.3 upgrades.

Similar bugs were fixed in nemo and cinnamon. Pkexec is known to cause issues
depending on how it's launched.

Specifying DO_NOT_REAP_CHILD in the spawn flags helps here. Afaik it makes it so
we're the parent of the pkexec process during launch. Pkexec fails to launch
otherwise.

gather_pid_callback() does nothing, it's just there to ack the pid callback. Afaik
this helps preventing zombie [defunct] processes when they terminate.