### PR TITLE
fix recently used documents sorting

### DIFF
--- a/usr/lib/linuxmint/mintMenu/plugins/recent.py
+++ b/usr/lib/linuxmint/mintMenu/plugins/recent.py
@@ -197,7 +197,7 @@ class pluginclass:
     def GetRecent(self, *args, **kargs):
         FileString=[]
         IconString=[]
-        RecentInfo=self.RecManagerInstance.get_items()
+        RecentInfo=sorted(self.RecManagerInstance.get_items(), key=lambda item: item.get_modified(), reverse=True)
         count=0
         MaxEntries=self.numentries
         if self.numentries == -1:


### PR DESCRIPTION
recently used documents were incorrectly sorted on when a file was first added to recently-used.xbel file, not reflecting when it was opened again later
this fix changes it so they are sorted correctly on when they were last used (when last their entry was modified in recently-used.xbel)

fixes https://github.com/linuxmint/mint20.2-beta/issues/10