### PR TITLE
remove mint-common dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Package: mintmenu
 Architecture: all
 Depends:
  ${misc:Depends},
- mint-common,
  python3,
  python3-apt,
  python3-configobj,


### PR DESCRIPTION
not needed after c293d485d9a76162c07da177299aec981197e0f4