### PR TITLE
Fix menu lag when keyboard shortcut is not set

### DIFF
--- a/usr/lib/linuxmint/mintMenu/keybinding.py
+++ b/usr/lib/linuxmint/mintMenu/keybinding.py
@@ -99,7 +99,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         return True
 
     def ungrab(self):
-        if self.keycode:
+        if hasattr(self, "keycode") and self.keycode:
             self.window.ungrab_key(self.keycode, X.AnyModifier, self.window)
 
     def rebind(self, key):


### PR DESCRIPTION
This PR fix #284.

without the PR with `journalctl -f` we have:
<img width="916" height="178" alt="image" src="https://github.com/user-attachments/assets/8cfe88d6-7891-4731-a92d-3d47b1403dad" />
